### PR TITLE
modified argument type to parametric

### DIFF
--- a/src/functions.jl
+++ b/src/functions.jl
@@ -19,7 +19,7 @@ function gevloglike(y::Real,μ::Real,σ::Real,ξ::Real)
 
 end
 
-function gevfitlmom(y::Array{Float64,1})
+function gevfitlmom(y::Array{N,1} where N)
 
     n = length(y)
     sort!(y)
@@ -41,7 +41,7 @@ function gevfitlmom(y::Array{Float64,1})
     return GeneralizedExtremeValue(μ, σ, ξ)
 end
 
-function gevfit(y::Array{Float64,1})
+function gevfit(y::Array{N,1} where N)
 
     # only MLE for the moment
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,5 +5,7 @@ else
     using Test
 end
 
+include("script.jl")
+
 # write your own tests here
 @test 1 == 2


### PR DESCRIPTION
Modification des arguments pour les fonctions `gevfitlmom` et `gevfit`.

En spécifiant `Array{N, 1} where N`, le compilateur va compiler pour les Float32, Float64, Int, etc...