### PR TITLE
Pointing to the dev branch

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -19,6 +19,7 @@ makedocs(sitename = "Extremes.jl",
 if CI
     deploydocs(
     repo   = "github.com/jojal5/Extremes.jl.git",
+    devbranch = "dev",
     target = "build"
     )
 end

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -20,6 +20,7 @@ if CI
     deploydocs(
     repo   = "github.com/jojal5/Extremes.jl.git",
     devbranch = "dev",
+    push_preview = true,
     target = "build"
     )
 end


### PR DESCRIPTION
The idea of a "latest" documentation is to track current development. Our method relies on the branch `dev`.

With this PR, deploydocs for dev branch is now pointing to the `dev` branch instead of master

```julia
help?> deploydocs
devbranch is the branch that "tracks" the in-development version of the generated documentation. 
By default this value is set to "master".
```
edit - Also added a `push_preview`. Will be useful for PR with lots of documentation.